### PR TITLE
fix shutdown is not properly completed

### DIFF
--- a/can_remote/client.py
+++ b/can_remote/client.py
@@ -89,6 +89,9 @@ class RemoteBus(can.bus.BusABC):
                 break
             except RemoteError:
                 pass
+        # Shutdown on parent side for proper state 
+        # (like _is_shutdown flag must be False when shutdown is finished)
+        super().shutdown()
         logger.debug('Network connection closed')
 
 


### PR DESCRIPTION
python-can has some assumptions for proper shutdown on BusABC.
I think RemoteBus's shutdown needs to call the parent's shutdown method. 
Please consider this change and if you have any suggestion please let me know.

Thanks.
