### PR TITLE
Missing super().__init__(channel) in RemoteBus

### DIFF
--- a/can_remote/client.py
+++ b/can_remote/client.py
@@ -36,6 +36,7 @@ class RemoteBus(can.bus.BusABC):
         self.socket = websocket.socket
         self.channel_info = self.remote_protocol.channel_info
         self.channel = channel
+        super().__init__(channel)
 
     def fileno(self):
         return self.socket.fileno()


### PR DESCRIPTION
super().__init__(channel) is missing in RemoteBus which causes following errors:
```
"can/bus.py", line 379, in filters
return self._filters
AttributeError: 'RemoteBus' object has no attribute '_filters'. Did you mean: 'filters'?
```
and `self._is_shutdown` is not set to false.
